### PR TITLE
Stop GOT retrying for missing files

### DIFF
--- a/vfs.js
+++ b/vfs.js
@@ -33,6 +33,9 @@ module.exports = function (RED, _teamID, _projectID, _token) {
         },
         timeout: {
             request: 500
+        },
+        retry: {
+            limit: 0
         }
     })
 


### PR DESCRIPTION
By default GOT retries 404's multiple times. This stops it as it's never going to find the file.